### PR TITLE
Feat: add type challenges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
-# TS-Nederdy-Challanges
+# TS-Nerdery-Challanges
 
 ## Steps
 
 1. Fork this repo to your account
 2. Before you start making changes create a new `develop` branch (`git checkout -b develop`)
-3. Run `yarn install` in your terminar for install the dependencies
+3. Run `yarn install` in your terminal to install the dependencies
 
-## Content Chanllange
 
-You are given a list of temperatures that ocurred for major US cities over the past week. Temperature readings were taken ad inconsistent intervals. Process the temperature readings and create a function that will retun a summary of the temperature data for a given dat. The summary should include the following information:
+## First Challenge - Temperature Summary
 
-1. Fisrt temperature reading for the day
+You are given a list of temperatures that ocurred for major US cities over the past week. Temperature readings were taken in inconsistent intervals. Process the temperature readings and create a function that will retun a summary of the temperature data for a given day. The summary should include the following information:
+
+1. First temperature reading for the day
 2. Last temperature reading for the day
 3. Highest temperature reading for the day
 4. Lowest temperature reading for the day
 5. Average of temperature readings that day
 
-Description of the two function in the file `src/app.ts`
+Description of the two functions are in the file `src/app.ts`
 
-## Function Descriptions
+### Function Descriptions
 
 The `processReadings` function will be called once with a list temperature readings and return nothing.
 
@@ -29,3 +30,12 @@ When you have finished your challenge, please run the next command `yarn test` t
 Recomendation: for a better performance and clean code please run the command `yarn format` and `yarn lint`
 
 
+## Second Challenge - Types Challenges
+
+### Description
+
+The `types challenges` consist in 6 exercise that will have you recreating built-ins like `ReadOnly` and `ReturnType` and bulding custom ones like `OmitByType` and `MyAwaited`. You'll learn how to manipulate object properties, work with conditional types, and extract types from wrapped structures like `Promise`
+
+Description of the six exercises are in the file `src/type-exercises.ts`
+
+For each file, we expect you to implement the utility type and include an example showing how to use it. The goal is to create the type as specified and demonstrate its functionality with real-world code examples.

--- a/src/type-exercises.ts
+++ b/src/type-exercises.ts
@@ -132,5 +132,9 @@
  * }
  * 
  * type UserRequiredName = RequiredByKeys<User, 'name'>; 
- * // expected to be: { name: string; age?: number; address?: string }
+ * expected to be: { name: string; age?: number; address?: string }
  */
+
+// Add here your solution
+
+// Add here your example

--- a/src/type-exercises.ts
+++ b/src/type-exercises.ts
@@ -1,0 +1,136 @@
+/**
+ * Exercise #1: Filter object properties by type.
+ * 
+ * Using a utility type `OmitByType`, this example demonstrates how to pick properties 
+ * from a type `T` whose values are *not* assignable to a specified type `U`.
+ * 
+ * @example
+ * type OmitBoolean = OmitByType<{
+ *   name: string;
+ *   count: number;
+ *   isReadonly: boolean;
+ *   isEnable: boolean;
+ * }, boolean>; 
+ * 
+ * Resulting type:
+ * 
+ * { 
+ * name: string; 
+ * count: number; 
+ * }
+ */
+
+
+// Add here your solution
+
+// Add here your example
+
+/**
+ * Exercise #2: Implement the utility type `If<C, T, F>`, which evaluates a condition `C` 
+ * and returns one of two possible types:
+ * - `T` if `C` is `true`
+ * - `F` if `C` is `false`
+ * 
+ * @description
+ * - `C` is expected to be either `true` or `false`.
+ * - `T` and `F` can be any type.
+ * 
+ * @example
+ * type A = If<true, 'a', 'b'>;  // expected to be 'a'
+ * type B = If<false, 'a', 'b'>; // expected to be 'b'
+ */
+
+
+// Add here your solution
+
+// Add here your example
+
+/**
+ * Exercise #3: Recreate the built-in `Readonly<T>` utility type without using it.
+ * 
+ * @description
+ * Constructs a type that makes all properties of `T` readonly. 
+ * This means the properties of the resulting type cannot be reassigned.
+ * 
+ * @example
+ * interface Todo {
+ *   title: string;
+ *   description: string;
+ * }
+ * 
+ * const todo: MyReadonly<Todo> = {
+ *   title: "Hey",
+ *   description: "foobar"
+ * };
+ * 
+ * todo.title = "Hello";       // Error: cannot reassign a readonly property
+ * todo.description = "barFoo"; // Error: cannot reassign a readonly property
+ */
+
+
+// Add here your solution
+
+// Add here your example
+
+
+/**
+ * Exercise #4: Recreate the built-in `ReturnType<T>` utility type without using it.
+ * 
+ * @description
+ * The `MyReturnType<T>` utility type extracts the return type of a function type `T`.
+ * 
+ * @example
+ * const fn = (v: boolean) => {
+ *   if (v) {
+ *     return 1;
+ *   } else {
+ *     return 2;
+ *   }
+ * };
+ * 
+ * type a = MyReturnType<typeof fn>; // expected to be "1 | 2"
+ */
+
+// Add here your solution
+
+// Add here your example
+
+/**
+ * Exercise #5: Extract the type inside a wrapped type like `Promise`.
+ * 
+ * @description
+ * Implement a utility type `MyAwaited<T>` that retrieves the type wrapped in a `Promise` or similar structure.
+ * 
+ * If `T` is `Promise<ExampleType>`, the resulting type should be `ExampleType`.
+ * 
+ * @example
+ * type ExampleType = Promise<string>;
+ * 
+ * type Result = MyAwaited<ExampleType>; // expected to be "string"
+ */
+
+// Add here your solution
+
+// Add here your example
+
+
+/**
+ * Exercise 6: Create a utility type `RequiredByKeys<T, K>` that makes specific keys of `T` required.
+ * 
+ * @description
+ * The type takes two arguments:
+ * - `T`: The object type.
+ * - `K`: A union of keys in `T` that should be made required.
+ * 
+ * If `K` is not provided, the utility should behave like the built-in `Required<T>` type, making all properties required.
+ * 
+ * @example
+ * interface User {
+ *   name?: string;
+ *   age?: number;
+ *   address?: string;
+ * }
+ * 
+ * type UserRequiredName = RequiredByKeys<User, 'name'>; 
+ * // expected to be: { name: string; age?: number; address?: string }
+ */


### PR DESCRIPTION
This pull request add some Typescript utility exercises.

1. `OmitByType<T,U>`
2. `If<C,T,F>`
3. `MyReadonly<T>`
4. `MyReturnType<T>`
5. `MyAwaited<T>`
6. `RequiredByKeys<T,K>`

Also the read me was updated to add both section one for the temperature summary challenge and the other one to add details for the new section added.

_Note: there's a typo in the repo name `Nederdy`_